### PR TITLE
made login/signup mobile responsive and fixed login hover effects

### DIFF
--- a/client/src/components/login/login.css
+++ b/client/src/components/login/login.css
@@ -39,8 +39,15 @@ input {
     border-radius: .5rem;
 }
 
+.login__btn:hover {
+    cursor: pointer;
+    box-shadow: inset 0px 4px 4px var(--clr-shadow);
+    text-shadow: none;
+    background-color: #82A4D8;
+}
+
 .login__card {
-    width: 20%;
+    width: clamp(200px, 20%, 400px);
     background-color: #fff;
     box-shadow: 0 4px 4px var(--clr-shadow);
     border-radius: .5rem;

--- a/client/src/components/signUp/SignUp.js
+++ b/client/src/components/signUp/SignUp.js
@@ -72,10 +72,10 @@ function SignUp() {
             <button className="login__btn" type="submit">Submit</button>
           </div>
         </form>
-        <p className="prompt">
+      </section>
+      <p className="prompt">
           Already have an account? <Link className="prompt__link" to="/app/login">Log in</Link>
         </p>
-      </section>
     </div>
   );
 }


### PR DESCRIPTION
noticed I needed some small tweaks for consistency, and it was easy to make the login/signup layouts mobile responsive by using a "clamp" for the width instead of a fixed 20%