### PR TITLE
can no re-order components in project tree

### DIFF
--- a/client/src/components/projectEditor/ProjectEditor.js
+++ b/client/src/components/projectEditor/ProjectEditor.js
@@ -3,7 +3,7 @@ import { Link, useParams } from "react-router-dom";
 import { useEditorContext } from "../../utils/EditorState";
 import { useQuery, useMutation } from "@apollo/client";
 import { QUERY_PROJECT } from "../../utils/queries";
-import { REMOVE_COMPONENT } from "../../utils/mutations";
+import { REMOVE_COMPONENT, COMP_UP, COMP_DOWN } from "../../utils/mutations";
 // import { useState } from "react";
 import { ADD_PROJECT } from "../../utils/actions";
 import Toolbox from "../toolbox/Toolbox";
@@ -47,6 +47,8 @@ function ProjectEditor() {
   }, [data, dispatch, loading]);
 
   const [removeComponent, { error }] = useMutation(REMOVE_COMPONENT);
+  const [moveComponentUp, { upError }] = useMutation(COMP_UP);
+  const [moveComponentDown, { downError }] = useMutation(COMP_DOWN);
 
   const HandleEditRequest = async (e) => {
     const componentId = e.target.name;
@@ -57,6 +59,22 @@ function ProjectEditor() {
   const HandleDeleteRequest = async (e) => {
     const componentId = e.target.name;
     await removeComponent({
+      variables: { projectId: projectId, componentId: componentId },
+    });
+    await window.location.reload();
+  };
+
+  const HandleShiftUpRequest = async (e) => {
+    const componentId = e.target.name;
+    await moveComponentUp({
+      variables: { projectId: projectId, componentId: componentId },
+    });
+    await window.location.reload();
+  };
+
+  const HandleShiftDownRequest = async (e) => {
+    const componentId = e.target.name;
+    await moveComponentDown({
       variables: { projectId: projectId, componentId: componentId },
     });
     await window.location.reload();
@@ -148,6 +166,22 @@ function ProjectEditor() {
                           >
                             Del
                           </button>
+                          <div className="shift__buttons">
+                            <button
+                              className="list__btns edit"
+                              name={component._id}
+                              onClick={HandleShiftUpRequest}
+                            >
+                              UP
+                            </button>
+                            <button
+                              className="list__btns edit"
+                              name={component._id}
+                              onClick={HandleShiftDownRequest}
+                            >
+                              DWN
+                            </button>
+                          </div>
                           <div>
                             {openModal &&
                             component.compType === "header" &&

--- a/client/src/utils/mutations.js
+++ b/client/src/utils/mutations.js
@@ -73,3 +73,25 @@ mutation RemoveComponent($projectId: ID!, $componentId: ID!) {
   }
 }
 `;
+
+export const COMP_UP = gql`
+mutation EditComponent($projectId: ID!, $componentId: ID!) {
+  compUp(project_id: $projectId, component_id: $componentId) {
+    _id
+    title
+    imageUrl
+    text
+  }
+}
+`;
+
+export const COMP_DOWN = gql`
+mutation EditComponent($projectId: ID!, $componentId: ID!) {
+  compDown(project_id: $projectId, component_id: $componentId) {
+    _id
+    title
+    imageUrl
+    text
+  }
+}
+`;

--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -160,7 +160,75 @@ const resolvers = {
         { new: true } // return the project post update
       );
       
-      console.log("edit component ran");
+      return editedProj; //return the project
+    },
+
+    compDown: async (parent, { project_id, component_id }, context ) => {
+      const proj = await Project.findOne({ _id: project_id }); // go get the whole project (target by id)
+      const compArr = proj.componentArray; // set its componentArray to a variable
+      const upperLimit = compArr.length - 1; // -1 because we are calling the limit of an index 0 scenario
+
+      const myIndex = compArr.findIndex(el => { // function to return the index in which conditions apply...
+        if (el.id === component_id) { // match by id...
+          return true;
+        };
+        return false;
+      })
+
+      let newCompArr = [];
+
+      if (myIndex < upperLimit) { // if the things we want to move isn't already at the top
+        const myEl = compArr[myIndex]; // save the current info of the component
+        // the syntax for an "arr.splice()" is Param 1: starting index, Param 2: delete count, Param 3: Insertion
+        compArr.splice(myIndex, 1) // remove our element from array
+        compArr.splice((myIndex+1), 0, myEl) // go forward one index number and put the element back in
+        newCompArr = compArr; // set the output variable to our array
+      } else {
+        newCompArr = compArr; // just return the array as it was
+      };
+
+
+      const editedProj = await Project.findOneAndUpdate(
+        { _id: project_id }, // target by id
+        {
+          $set: { componentArray: newCompArr }, // new array with new ordering
+        },
+        { new: true } // return the project post update
+      );
+
+      return editedProj; //return the project
+    },
+    compUp: async (parent, { project_id, component_id }, context ) => {
+      const proj = await Project.findOne({ _id: project_id }); // go get the whole project (target by id)
+      const compArr = proj.componentArray; // set its componentArray to a variable
+
+      const myIndex = compArr.findIndex(el => { // function to return the index in which conditions apply...
+        if (el.id === component_id) { // match by id...
+          return true;
+        };
+        return false;
+      })
+
+      let newCompArr = [];
+
+      if (myIndex > 0) { // if this is not already the first element in the array
+        const myEl = compArr[myIndex]; // save the current info of the component
+        // the syntax for an "arr.splice()" is Param 1: starting index, Param 2: delete count, Param 3: Insertion
+        compArr.splice(myIndex, 1) // remove our element from array
+        compArr.splice((myIndex-1), 0, myEl) // go backward one index number and put the element back in
+        newCompArr = compArr; // set the output variable to our array
+      } else {
+        newCompArr = compArr; // just return the array as it was
+      };
+
+      const editedProj = await Project.findOneAndUpdate(
+        { _id: project_id }, // target by id
+        {
+          $set: { componentArray: newCompArr }, // new array with new ordering
+        },
+        { new: true } // return the project post update
+      );
+
       return editedProj; //return the project
     },
   },

--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -63,6 +63,8 @@ const typeDefs = gql`
       imageUrl: String
       text: String
     ): Component
+    compUp(project_id: ID!, component_id: ID!): Component
+    compDown(project_id: ID!, component_id: ID!): Component
   }
 `;
 


### PR DESCRIPTION
It doesn't look as good styling wise (can fix later), but you can now reorder the components in the project tree.